### PR TITLE
sort assembly binding redirects by name and publicKeyToken

### DIFF
--- a/AutoFix-VisualStudioFiles/AutoFix-VisualStudioFiles.Tests.ps1
+++ b/AutoFix-VisualStudioFiles/AutoFix-VisualStudioFiles.Tests.ps1
@@ -133,3 +133,50 @@ Describe "AutoFix-CsProj" {
         }
     }
 }
+
+$originalContent4 = @'
+<configuration>
+  <runtime>
+    <assemblyBinding>
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="null" culture="neutral" />
+        <codeBase version="1.2.11.0" href="bin\log4net-nokey\log4net.dll" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.13.0" newVersion="1.2.13.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+'@
+
+$referenceContent4 = @'
+<configuration>
+  <runtime>
+    <assemblyBinding>
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.13.0" newVersion="1.2.13.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="log4net" publicKeyToken="null" culture="neutral" />
+        <codeBase version="1.2.11.0" href="bin\log4net-nokey\log4net.dll" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+'@
+
+Describe "AutoFix-WebConfig" {
+    Context "the web.config contains multiple bindingRedirects with equal name" {
+        $testPath = "TestDrive:\web.config"
+        Set-Content $testPath -value $originalContent4
+        $modifiedFiles = AutoFix-WebConfig $testPath
+        $modifiedContent = Get-Content $testPath -Raw
+
+        It "should sort the duplicate bindingRedirect by name and publicKeyToken" {
+            $modifiedContent | Should Be $referenceContent4
+        }
+    }
+}

--- a/AutoFix-VisualStudioFiles/AutoFix-VisualStudioFiles.ps1
+++ b/AutoFix-VisualStudioFiles/AutoFix-VisualStudioFiles.ps1
@@ -55,7 +55,7 @@ Function Scan-ConfigFiles([System.IO.FileInfo[]] $files)
 			}
 			
 			if ($workingCopy.configuration.runtime.assemblyBinding -ne $null -and $workingCopy.configuration.runtime.assemblyBinding.ChildNodes.Count -gt 1){
-					$sorted = $workingCopy.configuration.runtime.assemblyBinding.dependentAssembly | sort { [string]$_.assemblyIdentity.name }
+					$sorted = $workingCopy.configuration.runtime.assemblyBinding.dependentAssembly | sort { [string]$_.assemblyIdentity.name; [string]$_.assemblyIdentity.publicKeyToken }
 					$lastChild = $sorted[-1]
 					$sorted[0..($sorted.Length-2)] | foreach {$workingCopy.configuration.runtime.assemblyBinding.InsertBefore($_,$lastChild)} | Out-Null
 			}


### PR DESCRIPTION
Assembly binding entries with the same name are getting swapped on every run.

This commit will sort duplicate assembly binding entries by name and by publicKeyToken to ensure a foreseeable sort order.
